### PR TITLE
Update attest to work with openmpi 5.

### DIFF
--- a/attest
+++ b/attest
@@ -400,7 +400,13 @@ def main():
     """
     # 0. Set up environment and input settings:
     # a. permit running more MPI processes than we have logical cores
+    # (openmpi 4 and 5)
     os.environ['OMPI_MCA_rmaps_base_oversubscribe'] = "1"
+    ompi_5_key = 'PRTE_MCA_rmaps_default_mapping_policy'
+    if ompi_5_key in os.environ.keys():
+        os.environ[ompi_5_key] = os.environ[ompi_5_key] + ":oversubscribe"
+    else:
+        os.environ[ompi_5_key] = ":oversubscribe"
     # b. completely disable OMP threading. HYPRE may try to parallelize itself
     # with threads which leads to disasterous performance since we expect that
     # all parallelization is done with MPI.


### PR DESCRIPTION
This version of openmpi reads a different set of environment variables.